### PR TITLE
Fix typos and broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### [All DAY DEVOPS 2017 SLIDES HERE](https://docs.google.com/presentation/d/1OiJD24-Mn4zoDZaDnAdl5bRfFsy_YmxZUdGuAhzuWZM/edit?usp=sharing)
 
-### [POST-CONFERENCE BLOG POST HERE](.)
+### [POST-CONFERENCE BLOG POST HERE](https://medium.com/what-about-security/all-day-devops-2017-removing-developers-shameful-secrets-f5aca3960316)
 
 ***
 

--- a/code/vault/2_ready_userpass.sh
+++ b/code/vault/2_ready_userpass.sh
@@ -1,5 +1,4 @@
-#//bin/bash
-export VAULT_ADDR="http://127.0.0.1:8200"
+#!/bin/bash
 
 # Make sure to have vault on your system before proceeding
 command -v vault >/dev/null 2>&1 || { echo >&2 "I require vault but it's not installed.  Aborting."; exit 1; }
@@ -23,10 +22,10 @@ vault policy-write vault_admin ./policies/vault_admin.hcl
 vault auth-enable userpass
 vault auth-enable approle
 
-# make a new user 'fabian'
+# make a new user based on the values defined in the .secret0 file
 vault write auth/userpass/users/${VAULT_USERNAME} policies=vault_admin password=${VAULT_PASSWORD}
 
-# login to vault as fabian
+# login to vault as new user
 vault auth -method=userpass username=${VAULT_USERNAME} password=${VAULT_PASSWORD}
 vault token-lookup
 

--- a/code/vault/3_ready_approle.sh
+++ b/code/vault/3_ready_approle.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-export VAULT_ADDR="http://127.0.0.1:8200"
 
 # Make sure to have vault on your system before proceeding
 command -v vault >/dev/null 2>&1 || { echo >&2 "I require vault but it's not installed.  Aborting."; exit 1; }

--- a/code/vault/4_test_approle.sh
+++ b/code/vault/4_test_approle.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-export VAULT_ADDR="http://127.0.0.1:8200"
 export SECRET_PATH='secret/example/test'
 
 # Make sure to have vault on your system before proceeding

--- a/code/vault/README.md
+++ b/code/vault/README.md
@@ -26,7 +26,7 @@ Run scripts in order:
 
 1. [`./0_update_requirements.sh`](./0_update_requirements.sh)
 
-2. [`./1_start_server.sh`](./1_start_server)
+2. [`./1_start_server.sh`](./1_start_server.sh)
 
 3. [`./2_ready_userpass.sh`](./2_ready_userpass.sh)
 


### PR DESCRIPTION
Fixing some typos and broken links/references to static values that are now dynamic.
Also, I removed the VAULT_ADDRESS environment variable in some of the scripts, as this should come from sourcing .secret0.
Sourcing .secret0 if the env variables are not set may be another enhancement to consider.